### PR TITLE
readme: make first line descriptive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[h1]Intro[/h1]
-
 Three new stat mechanics are added to the game: Water, Food and Sleep.
 
 To restore food and water stats you have to use consumable items, like Clang Kola and Cosmic Coffee.


### PR DESCRIPTION
I suppose you're using the README file for the workshop description also?..

First line of the workshop description is shown in the in-game mod selection window. It's nice for this line to be descriptive.

Before this PR, it shows as follows:

![image](https://user-images.githubusercontent.com/18170434/202016655-acb435a2-dcbc-49fa-8ade-35513ed5824c.png)

The other line-change is probably github adding a newline or something.
